### PR TITLE
Circuits.GPIO library updates

### DIFF
--- a/lib/scenic_driver_gpio.ex
+++ b/lib/scenic_driver_gpio.ex
@@ -28,7 +28,7 @@ defmodule ScenicDriverGPIO do
     end)
   end
 
-  def handle_info({:gpio, pin, _, edge}, s) do
+  def handle_info({:circuits_gpio, pin, _, edge}, s) do
     gpio = Map.get(s.gpio, pin)
 
     event =

--- a/lib/scenic_driver_gpio.ex
+++ b/lib/scenic_driver_gpio.ex
@@ -20,8 +20,7 @@ defmodule ScenicDriverGPIO do
       pin = gpio[:pin] || raise "No pin was defined"
       pull_mode = gpio[:pull_mode] || :not_set
 
-      {:ok, gpio_ref} = GPIO.open(pin, :input)
-      :ok = GPIO.set_pull_mode(gpio_ref, pull_mode)
+      {:ok, gpio_ref} = GPIO.open(pin, :input, pull_mode: pull_mode)
       :ok = GPIO.set_interrupts(gpio_ref, :both)
 
       info = Map.put(gpio, :ref, gpio_ref)

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ScenicDriverGPIO.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:circuits_gpio, "~> 0.3"},
+      {:circuits_gpio, "~> 0.4"},
       {:scenic, "~> 0.9"},
       {:ex_doc, "~> 0.11", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ScenicDriverGPIO.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:circuits_gpio, "~> 0.1"},
+      {:circuits_gpio, "~> 0.3"},
       {:scenic, "~> 0.9"},
       {:ex_doc, "~> 0.11", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "circuits_gpio": {:hex, :circuits_gpio, "0.1.0", "cee5048dd67160f11b110315f07130d4ccae252fb485fc5793e3447a92bfae65", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "circuits_gpio": {:hex, :circuits_gpio, "0.3.1", "bfbc01bba0de0d820ee5cc60593d809095f10922f65de8bde26795790d830250", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "circuits_gpio": {:hex, :circuits_gpio, "0.3.1", "bfbc01bba0de0d820ee5cc60593d809095f10922f65de8bde26795790d830250", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "circuits_gpio": {:hex, :circuits_gpio, "0.4.0", "f1ce5a50921b13f23847c47589b51bdd93afe372fabfb9a58497cad515a5cc98", [:make, :mix], [{:elixir_make, "~> 0.5", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.6.0", "e0fd985525e8d42352782bd76253105fbab0a783ac298708ca9020636c9568af", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.11.0", "aa3446f67356afa5801618867587a8863f176f9c632fb62b20f49bd1ea335e8a", [:mix], [{:makeup, "~> 0.6", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.5.1", "cee27c69bddcd6e333a24f2313786d1c9a970c49fcf700ecf1f7246f3a210f39", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "scenic": {:hex, :scenic, "0.9.0", "129594f918b4e2dd97465b95b4fb3582294ac6bb3e931f12edd09913743964eb", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
 }


### PR DESCRIPTION
This combines the `pull_mode` setting with the open call to delete a line of code and updates to the latest version of `circuits_gpio`.